### PR TITLE
Seperation of dolphin logic

### DIFF
--- a/Client/abstractGameHandler.py
+++ b/Client/abstractGameHandler.py
@@ -1,15 +1,19 @@
 from abc import ABC, abstractmethod
-from typing import Dict, Coroutine
+from typing import Dict, List
 
 
 class AbstractGameHandler(ABC):
+
+    @abstractmethod
+    def connect(self) -> None:
+        pass
 
     @abstractmethod
     def is_connected(self) -> bool:
         pass
 
     @abstractmethod
-    def give_item(self, item_id: int) -> None:
+    def give_item(self, item_id: int) -> bool:
         pass
 
     @abstractmethod
@@ -20,3 +24,10 @@ class AbstractGameHandler(ABC):
     def get_items(self) -> Dict[int, int]:
         pass
 
+    @abstractmethod
+    def read_chest_items(self) -> List[int]:
+        pass
+
+    @abstractmethod
+    def clear_chest_items(self) -> None:
+        pass

--- a/Client/clientCommunication.py
+++ b/Client/clientCommunication.py
@@ -6,7 +6,7 @@ import json
 from typing import List
 
 import websockets
-from .dolphinGameHandler import connect_dolphin
+from .dolphinGameHandler import DolphinGameHandler
 
 from PySide6.QtWidgets import QListWidget
 from Client.stompframemanager import StompFrameManager
@@ -15,17 +15,14 @@ from Model.serverConfig import ServerConfig
 from Model.setUpDto import SetUpDto
 from Model.config import Config
 
-items_to_process: List[ItemDto] = list()
-items_to_send: List[ItemDto] = list()
-dolphin_busy: bool = False
 world_id: int = Config.get_config().get_world_id()
 game_room: str = Config.get_config().get_game_room()
 event_scanning: bool = Config.get_config().Scanner_Enabled
 disable_multiplayer: bool = Config.get_config().Disable_Multiplayer
-
+dolphin_game_handler: DolphinGameHandler = DolphinGameHandler(world_id)
 
 async def start_connections(server_config: ServerConfig, set_up_dto: SetUpDto, clientOutput: QListWidget) -> None:
-    asyncio.create_task(connect_dolphin(world_id))
+    asyncio.create_task(dolphin_game_handler.connect_dolphin())
     if not disable_multiplayer:
         await client(server_config)
 
@@ -42,9 +39,9 @@ async def client(server_config: ServerConfig) -> None:
                 asyncio.create_task(listen_to_server(client_websocket))
                 print(f"Successfully connected to the Server")
                 while True:
-                    for itemDto in items_to_send:
+                    for itemDto in dolphin_game_handler.get_item_to_send():
                         await client_websocket.send(frame_manager.send_json(f"/app/item/{game_room}", json.dumps(itemDto.as_dict())))
-                        items_to_send.remove(itemDto)
+                        dolphin_game_handler.remove_item_to_send(itemDto)
                     await asyncio.sleep(0)
             else:
                 print("Failed to Subscribe to Item Queue, like a bad config.txt")
@@ -63,5 +60,5 @@ async def handle_message(message) -> None:
         contents = message.split("\n")
         item_dto = ItemDto.from_dict(json.loads(contents[-1][:-1]))
         if item_dto.sourcePlayerWorldId != world_id:
-            items_to_process.append(item_dto)
+            dolphin_game_handler.push_item_to_process(item_dto)
 

--- a/Client/dolphinGameHandler.py
+++ b/Client/dolphinGameHandler.py
@@ -1,21 +1,87 @@
 """
 Handles requests to dolphin.
 """
-from typing import Dict
+import asyncio
+from asyncio import Task
+
+from typing import Dict, List, Coroutine, Any
 import Dolphin.windWakerInterface as WWI
 
 from Client.abstractGameHandler import AbstractGameHandler
+from Model.itemDto import ItemDto
 
 
 class DolphinGameHandler(AbstractGameHandler):
+    _items_to_process: List[ItemDto] = list() # This needs to hook back into the client somehow
+    _items_to_send: List[ItemDto] = list()  # This needs to hook back into the client somehow
+    _world_id: int = 0
+
+    def __init__(self, world_id: int):
+        _world_id = world_id
+
     def is_connected(self) -> bool:
         return WWI.is_hooked()
 
-    def give_item(self, item_id: int) -> None:
-        pass
+    def give_item(self, item_id: int) -> bool:
+        try:
+            if WWI.is_title_screen():
+                return False
+            WWI.give_item_by_value(item_id)
+            return True
+        except RuntimeError as exc:
+            print(exc)
+            del exc
+            return False
 
     def toggle_event(self, event_type: str, event_index: int, enable: bool) -> None:
         pass
 
     def get_items(self) -> Dict[int, int]:
         pass
+
+    async def process_items(self) -> None:
+        while len(self._items_to_process) > 0:
+            item_dto = self._items_to_process[-1]
+            print_item_dto(item_dto)
+            try:
+                if not self.give_item(item_dto.itemId):
+                    await asyncio.sleep(3)
+                    continue
+                self._items_to_process.pop()
+                await asyncio.sleep(0)
+            except RuntimeError as exc:
+                print(exc)
+                del exc
+
+    async def handle_dolphin(self) -> None:
+        print("Connected To Dolphin")
+        while WWI.is_hooked():  # Thread set interval instead of a while loop would be better
+            try:
+                state = WWI.read_chest_items()
+                if state[0] != 0 and state[1] != 0 and state[1] != 0xFF:
+                    item_dto = ItemDto(self._world_id, 0, state[1])  # World ID should be set in client
+                    print_item_dto(item_dto)
+                    self._items_to_send.append(item_dto)
+                    WWI.clear_chest_items()
+            except RuntimeError as rne:
+                del rne
+            finally:
+                if len(self._items_to_process) > 0:
+                    asyncio.create_task(self.process_items())
+            await asyncio.sleep(0)
+        print("Disconnected from Dolphin, attempting to reconnect.....")
+
+
+async def connect_dolphin(world_id: int) -> Task:
+    print("Connecting to Dolphin")
+    while not WWI.is_hooked():
+        WWI.hook()
+        if WWI.is_hooked():
+            break
+        await asyncio.sleep(15)
+        print("Dolphin was not found, trying again in 15 seconds.")
+    return asyncio.create_task(DolphinGameHandler(world_id).handle_dolphin())
+
+
+def print_item_dto(itemDto: ItemDto) -> None:
+    print(f"{WWR.item_name_dict[itemDto.itemId]} was found in world {itemDto.sourcePlayerWorldId}")

--- a/Client/dolphinGameHandler.py
+++ b/Client/dolphinGameHandler.py
@@ -4,7 +4,7 @@ Handles requests to dolphin.
 import asyncio
 from asyncio import Task
 
-from typing import Dict, List, Coroutine, Any
+from typing import Dict, List
 import Dolphin.windWakerInterface as WWI
 
 from Client.abstractGameHandler import AbstractGameHandler
@@ -71,16 +71,24 @@ class DolphinGameHandler(AbstractGameHandler):
             await asyncio.sleep(0)
         print("Disconnected from Dolphin, attempting to reconnect.....")
 
+    def get_item_to_send(self) -> List[ItemDto]:
+        return self._items_to_send
 
-async def connect_dolphin(world_id: int) -> Task:
-    print("Connecting to Dolphin")
-    while not WWI.is_hooked():
-        WWI.hook()
-        if WWI.is_hooked():
-            break
-        await asyncio.sleep(15)
-        print("Dolphin was not found, trying again in 15 seconds.")
-    return asyncio.create_task(DolphinGameHandler(world_id).handle_dolphin())
+    def remove_item_to_send(self, item_dto:ItemDto):
+        self._items_to_send.remove(item_dto)
+
+    def push_item_to_process(self, item_dto: ItemDto) -> None:
+        self._items_to_process.append(item_dto)
+
+    async def connect_dolphin(self) -> Task:
+        print("Connecting to Dolphin")
+        while not WWI.is_hooked():
+            WWI.hook()
+            if WWI.is_hooked():
+                break
+            await asyncio.sleep(15)
+            print("Dolphin was not found, trying again in 15 seconds.")
+        return asyncio.create_task(self.handle_dolphin())
 
 
 def print_item_dto(itemDto: ItemDto) -> None:

--- a/Client/dolphinGameHandler.py
+++ b/Client/dolphinGameHandler.py
@@ -8,16 +8,14 @@ from typing import Dict, List
 import Dolphin.windWakerInterface as WWI
 
 from Client.abstractGameHandler import AbstractGameHandler
-from Model.itemDto import ItemDto
 
 
 class DolphinGameHandler(AbstractGameHandler):
-    _items_to_process: List[ItemDto] = list() # This needs to hook back into the client somehow
-    _items_to_send: List[ItemDto] = list()  # This needs to hook back into the client somehow
-    _world_id: int = 0
-
     def __init__(self, world_id: int):
         _world_id = world_id
+
+    def connect(self):
+        WWI.hook()
 
     def is_connected(self) -> bool:
         return WWI.is_hooked()
@@ -39,57 +37,8 @@ class DolphinGameHandler(AbstractGameHandler):
     def get_items(self) -> Dict[int, int]:
         pass
 
-    async def process_items(self) -> None:
-        while len(self._items_to_process) > 0:
-            item_dto = self._items_to_process[-1]
-            print_item_dto(item_dto)
-            try:
-                if not self.give_item(item_dto.itemId):
-                    await asyncio.sleep(3)
-                    continue
-                self._items_to_process.pop()
-                await asyncio.sleep(0)
-            except RuntimeError as exc:
-                print(exc)
-                del exc
+    def read_chest_items(self) -> List[int]:
+        return WWI.read_chest_items()
 
-    async def handle_dolphin(self) -> None:
-        print("Connected To Dolphin")
-        while WWI.is_hooked():  # Thread set interval instead of a while loop would be better
-            try:
-                state = WWI.read_chest_items()
-                if state[0] != 0 and state[1] != 0 and state[1] != 0xFF:
-                    item_dto = ItemDto(self._world_id, 0, state[1])  # World ID should be set in client
-                    print_item_dto(item_dto)
-                    self._items_to_send.append(item_dto)
-                    WWI.clear_chest_items()
-            except RuntimeError as rne:
-                del rne
-            finally:
-                if len(self._items_to_process) > 0:
-                    asyncio.create_task(self.process_items())
-            await asyncio.sleep(0)
-        print("Disconnected from Dolphin, attempting to reconnect.....")
-
-    def get_item_to_send(self) -> List[ItemDto]:
-        return self._items_to_send
-
-    def remove_item_to_send(self, item_dto:ItemDto):
-        self._items_to_send.remove(item_dto)
-
-    def push_item_to_process(self, item_dto: ItemDto) -> None:
-        self._items_to_process.append(item_dto)
-
-    async def connect_dolphin(self) -> Task:
-        print("Connecting to Dolphin")
-        while not WWI.is_hooked():
-            WWI.hook()
-            if WWI.is_hooked():
-                break
-            await asyncio.sleep(15)
-            print("Dolphin was not found, trying again in 15 seconds.")
-        return asyncio.create_task(self.handle_dolphin())
-
-
-def print_item_dto(itemDto: ItemDto) -> None:
-    print(f"{WWR.item_name_dict[itemDto.itemId]} was found in world {itemDto.sourcePlayerWorldId}")
+    def clear_chest_items(self):
+        WWI.clear_chest_items()

--- a/Client/gameHandler.py
+++ b/Client/gameHandler.py
@@ -1,0 +1,74 @@
+import asyncio
+from asyncio import Task
+from typing import List
+
+from Client.dolphinGameHandler import DolphinGameHandler
+from Model.itemDto import ItemDto
+from Client.abstractGameHandler import AbstractGameHandler
+import Dolphin.windWakerResources as WWR
+
+
+class GameHandler:
+    _items_to_process: List[ItemDto] = list()
+    _items_to_send: List[ItemDto] = list()
+    _world_id: int = 0
+
+    _console_handler: AbstractGameHandler
+
+    def __init__(self, world_id: int):
+        self._console_handler = DolphinGameHandler(world_id)
+
+    async def process_items(self) -> None:
+        while len(self._items_to_process) > 0:
+            item_dto = self._items_to_process[-1]
+            print_item_dto(item_dto)
+            try:
+                if not self._console_handler.give_item(item_dto.itemId):
+                    await asyncio.sleep(3)
+                    continue
+                self._items_to_process.pop()
+                await asyncio.sleep(0)
+            except RuntimeError as exc:
+                print(exc)
+                del exc
+
+    async def handle(self) -> None:
+        print("Connected To Console")
+        while self._console_handler.is_connected():  # Thread set interval instead of a while loop would be better
+            try:
+                state = self._console_handler.read_chest_items()
+                if state[0] != 0 and state[1] != 0 and state[1] != 0xFF:
+                    item_dto = ItemDto(self._world_id, 0, state[1])  # World ID should be set in client
+                    print_item_dto(item_dto)
+                    self._items_to_send.append(item_dto)
+                    self._console_handler.clear_chest_items()
+            except RuntimeError as rne:
+                del rne
+            finally:
+                if len(self._items_to_process) > 0:
+                    asyncio.create_task(self.process_items())
+            await asyncio.sleep(0)
+        print("Disconnected from Console, attempting to reconnect.....")
+
+    async def connect(self) -> Task:
+        print("Connecting to Console")
+        while not self._console_handler.is_connected():
+            self._console_handler.connect()
+            if self._console_handler.is_connected():
+                break
+            await asyncio.sleep(15)
+            print("Console was not found, trying again in 15 seconds.")
+        return asyncio.create_task(self.handle())
+
+    def get_item_to_send(self) -> List[ItemDto]:
+        return self._items_to_send
+
+    def remove_item_to_send(self, item_dto:ItemDto):
+        self._items_to_send.remove(item_dto)
+
+    def push_item_to_process(self, item_dto: ItemDto) -> None:
+        self._items_to_process.append(item_dto)
+
+
+def print_item_dto(itemDto: ItemDto) -> None:
+    print(f"{WWR.item_name_dict[itemDto.itemId]} was found in world {itemDto.sourcePlayerWorldId}")

--- a/Dolphin/windWakerInterface.py
+++ b/Dolphin/windWakerInterface.py
@@ -421,7 +421,7 @@ def toggle_bit_flag(address: int, offset: int, enable: bool) -> None:
 
 
 
-def check_valid_state() -> bool:
+def is_title_screen() -> bool:
     curr_val = dme.read_bytes(0x803C9D3C, 8)
     return curr_val == b'Name\x00\x00\x00\x00' or curr_val == b'sea_T\x00\x00\x00'
 


### PR DESCRIPTION
There is now a clear seperation between game handling commands and dolphin commands. Currently `gameHandler` will always create a new `dolphin` instance, but this can be changed due to the usage of an abstract class.

`Client/dolphinGameHandler.py` handles the direct interface between the client and dolphin. We expect all dolphin related code to sit within this file. Uses the abstract class.

`Client/gameHandler.py` handles the logic between the client and the console. Console being both dolphin and the Wii. We should not expect and dolphin specific code here.

### Things to look into
- The only thing I haven't removed is the usage of `Dolphin.windWakerResources` in `gameHandler` as it is used to print messages.
- `read_chest_items` and `clear_chest_items` could probably be more generic and switched to something else? It may not need to be a abstract class method.