### PR TITLE
Add more function to multiworld client GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /shelf/
 /workspace.xml
 /.idea/
+__pycache__/

--- a/Client/clientCommunication.py
+++ b/Client/clientCommunication.py
@@ -22,15 +22,15 @@ event_scanning: bool = Config.get_config().Scanner_Enabled
 disable_multiplayer: bool = Config.get_config().Disable_Multiplayer
 game_handler: ClientGameConnection = ClientGameConnection(world_id)
 
-global logger
+global gui_logger
 async def log(message: str) -> None:
-    global logger
-    assert isinstance(logger, Signal)
-    logger.emit(message)
+    global gui_logger
+    assert isinstance(gui_logger, Signal)
+    gui_logger.emit(message)
 
 async def start_connections(server_config: ServerConfig, set_up_dto: SetUpDto, gui_log: Signal(str)) -> None:
-    global logger
-    logger = gui_log
+    global gui_logger
+    gui_logger = gui_log
     asyncio.create_task(game_handler.connect())
     if not disable_multiplayer:
         await client(server_config)

--- a/Client/clientCommunication.py
+++ b/Client/clientCommunication.py
@@ -40,13 +40,13 @@ async def client(server_config: ServerConfig) -> None:
     frame_manager = StompFrameManager(server_config)
     try:
         async with websockets.connect("ws://" + server_config.get_uri()) as client_websocket:
-            print(f"Attempting to Connect to {game_room}.........")
+            log(f"Attempting to Connect to {game_room}.........")
             await client_websocket.send(frame_manager.connect(server_config.server_ip))
             foo = await client_websocket.recv()
             if not foo.startswith("ERROR"):
                 await client_websocket.send(frame_manager.subscribe(f"/topic/item/{game_room}"))
                 asyncio.create_task(listen_to_server(client_websocket))
-                print(f"Successfully connected to the Server")
+                log(f"Successfully connected to the Server")
                 while True:
                     for itemDto in game_handler.get_item_to_send():
                         await client_websocket.send(frame_manager.send_json(f"/app/item/{game_room}", json.dumps(itemDto.as_dict())))
@@ -58,17 +58,17 @@ async def client(server_config: ServerConfig) -> None:
                 try:
                     await client_websocket.send(frame_manager.disconnect(""))
                     await client_websocket.close()
-                    print("Successfully disconnected from server!")
+                    log("Successfully disconnected from server!")
                     QThread.currentThread().quit() # Tells thread to fully end
                 except Exception as e:
-                    print(f"Error disconnecting from server:\n{e}")
+                    log(f"Error disconnecting from server:\n{e}")
                 
             else:
                 raise ServerDisconnectWarning()
     except ServerDisconnectWarning as sdw:
-        print("Failed to Subscribe to the Item Queue. Bad Server URL?")
+        log("Failed to Subscribe to the Item Queue. Bad Server URL?")
     except Exception as e:
-        print("Problem with Server connection, please check the status with the Server host.")
+        log("Problem with Server connection, please check the status with the Server host.")
 
 
 async def listen_to_server(client_connection) -> None:

--- a/Client/clientCommunication.py
+++ b/Client/clientCommunication.py
@@ -60,7 +60,7 @@ async def client(server_config: ServerConfig) -> None:
                 try:
                     await client_websocket.send(frame_manager.disconnect(""))
                     await client_websocket.close()
-                    await log("Successfully disconnected from server!")
+                    await log("Successfully disconnected from the Server")
                     QThread.currentThread().quit() # Tells thread to fully end
                 except Exception as e:
                     await log(f"Error disconnecting from server:\n{e}")

--- a/Client/clientCommunication.py
+++ b/Client/clientCommunication.py
@@ -22,15 +22,15 @@ event_scanning: bool = Config.get_config().Scanner_Enabled
 disable_multiplayer: bool = Config.get_config().Disable_Multiplayer
 game_handler: ClientGameConnection = ClientGameConnection(world_id)
 
-global gui_logger
+global gui_logger_signal
 async def log(message: str) -> None:
-    global gui_logger
-    assert isinstance(gui_logger, Signal)
-    gui_logger.emit(message)
+    global gui_logger_signal
+    assert isinstance(gui_logger_signal, Signal)
+    gui_logger_signal.emit(message)
 
-async def start_connections(server_config: ServerConfig, set_up_dto: SetUpDto, gui_log: Signal(str)) -> None:
-    global gui_logger
-    gui_logger = gui_log
+async def start_connections(server_config: ServerConfig, set_up_dto: SetUpDto, gui_logger_signal_source: Signal(str)) -> None:
+    global gui_logger_signal
+    gui_logger_signal = gui_logger_signal_source
     asyncio.create_task(game_handler.connect())
     if not disable_multiplayer:
         await client(server_config)

--- a/Client/clientCommunication.py
+++ b/Client/clientCommunication.py
@@ -31,7 +31,7 @@ async def log(message: str) -> None:
 async def start_connections(server_config: ServerConfig, set_up_dto: SetUpDto, gui_logger_signal_source: Signal(str)) -> None:
     global gui_logger_signal
     gui_logger_signal = gui_logger_signal_source
-    asyncio.create_task(game_handler.connect())
+    asyncio.create_task(game_handler.connect(gui_logger_signal))
     if not disable_multiplayer:
         await client(server_config)
 

--- a/Client/clientCommunication.py
+++ b/Client/clientCommunication.py
@@ -25,8 +25,10 @@ game_handler: ClientGameConnection = ClientGameConnection(world_id)
 global gui_logger_signal
 async def log(message: str) -> None:
     global gui_logger_signal
-    assert isinstance(gui_logger_signal, Signal)
-    gui_logger_signal.emit(message)
+    if isinstance(gui_logger_signal, Signal):
+        gui_logger_signal.emit(message)
+    else:
+        print(message)
 
 async def start_connections(server_config: ServerConfig, set_up_dto: SetUpDto, gui_logger_signal_source: Signal(str)) -> None:
     global gui_logger_signal

--- a/Client/clientCommunication.py
+++ b/Client/clientCommunication.py
@@ -9,7 +9,7 @@ import websockets
 from util.clientExceptions import ServerDisconnectWarning
 from .clientGameConnection import ClientGameConnection
 
-from PySide6.QtCore import Slot
+from PySide6.QtCore import Signal
 from util.stompframemanager import StompFrameManager
 from Model.itemDto import ItemDto
 from Model.serverConfig import ServerConfig
@@ -22,8 +22,15 @@ event_scanning: bool = Config.get_config().Scanner_Enabled
 disable_multiplayer: bool = Config.get_config().Disable_Multiplayer
 game_handler: ClientGameConnection = ClientGameConnection(world_id)
 
+global logger
+async def log(message: str) -> None:
+    global logger
+    assert isinstance(logger, Signal)
+    logger.emit(message)
 
-async def start_connections(server_config: ServerConfig, set_up_dto: SetUpDto, gui_log: Slot(str)) -> None:
+async def start_connections(server_config: ServerConfig, set_up_dto: SetUpDto, gui_log: Signal(str)) -> None:
+    global logger
+    logger = gui_log
     asyncio.create_task(game_handler.connect())
     if not disable_multiplayer:
         await client(server_config)

--- a/Client/clientCommunication.py
+++ b/Client/clientCommunication.py
@@ -9,7 +9,7 @@ import websockets
 from util.clientExceptions import ServerDisconnectWarning
 from .clientGameConnection import ClientGameConnection
 
-from PySide6.QtWidgets import QListWidget
+from PySide6.QtCore import Slot
 from util.stompframemanager import StompFrameManager
 from Model.itemDto import ItemDto
 from Model.serverConfig import ServerConfig
@@ -23,7 +23,7 @@ disable_multiplayer: bool = Config.get_config().Disable_Multiplayer
 game_handler: ClientGameConnection = ClientGameConnection(world_id)
 
 
-async def start_connections(server_config: ServerConfig, set_up_dto: SetUpDto, clientOutput: QListWidget) -> None:
+async def start_connections(server_config: ServerConfig, set_up_dto: SetUpDto, gui_log: Slot(str)) -> None:
     asyncio.create_task(game_handler.connect())
     if not disable_multiplayer:
         await client(server_config)

--- a/Client/clientCommunication.py
+++ b/Client/clientCommunication.py
@@ -40,13 +40,13 @@ async def client(server_config: ServerConfig) -> None:
     frame_manager = StompFrameManager(server_config)
     try:
         async with websockets.connect("ws://" + server_config.get_uri()) as client_websocket:
-            log(f"Attempting to Connect to {game_room}.........")
+            await log(f"Attempting to Connect to {game_room}.........")
             await client_websocket.send(frame_manager.connect(server_config.server_ip))
             foo = await client_websocket.recv()
             if not foo.startswith("ERROR"):
                 await client_websocket.send(frame_manager.subscribe(f"/topic/item/{game_room}"))
                 asyncio.create_task(listen_to_server(client_websocket))
-                log(f"Successfully connected to the Server")
+                await log(f"Successfully connected to the Server")
                 while True:
                     for itemDto in game_handler.get_item_to_send():
                         await client_websocket.send(frame_manager.send_json(f"/app/item/{game_room}", json.dumps(itemDto.as_dict())))
@@ -58,17 +58,17 @@ async def client(server_config: ServerConfig) -> None:
                 try:
                     await client_websocket.send(frame_manager.disconnect(""))
                     await client_websocket.close()
-                    log("Successfully disconnected from server!")
+                    await log("Successfully disconnected from server!")
                     QThread.currentThread().quit() # Tells thread to fully end
                 except Exception as e:
-                    log(f"Error disconnecting from server:\n{e}")
+                    await log(f"Error disconnecting from server:\n{e}")
                 
             else:
                 raise ServerDisconnectWarning()
     except ServerDisconnectWarning as sdw:
-        log("Failed to Subscribe to the Item Queue. Bad Server URL?")
+        await log("Failed to Subscribe to the Item Queue. Bad Server URL?")
     except Exception as e:
-        log("Problem with Server connection, please check the status with the Server host.")
+        await log("Problem with Server connection, please check the status with the Server host.")
 
 
 async def listen_to_server(client_connection) -> None:

--- a/Client/clientGameConnection.py
+++ b/Client/clientGameConnection.py
@@ -25,7 +25,7 @@ class ClientGameConnection:
     async def process_items(self) -> None:
         while len(self._items_to_process) > 0:
             item_dto = self._items_to_process[-1]
-            await self.print_item_dto(item_dto)
+            await self.log(item_dto.get_simple_output())
             try:
                 if not await self._console_handler.give_item(item_dto.itemId):
                     await asyncio.sleep(3)
@@ -43,7 +43,7 @@ class ClientGameConnection:
                 state = await self._console_handler.get_queued_items()
                 if state[0] != 0 and state[1] != 0 and state[1] != 0xFF:
                     item_dto = ItemDto(self._world_id, 0, state[1])  # World ID should be set in client
-                    await self.print_item_dto(item_dto)
+                    await self.log(item_dto.get_simple_output())
                     self._items_to_send.append(item_dto)
                     await self._console_handler.clear_queued_items()
             except RuntimeError as rne:
@@ -79,6 +79,3 @@ class ClientGameConnection:
 
     def push_item_to_process(self, item_dto: ItemDto) -> None:
         self._items_to_process.append(item_dto)
-    
-    async def print_item_dto(self, itemDto: ItemDto) -> None:
-        await self.log(f"{WWR.item_name_dict[itemDto.itemId]} was found in world {itemDto.sourcePlayerWorldId}")

--- a/Client/clientGameConnection.py
+++ b/Client/clientGameConnection.py
@@ -7,6 +7,8 @@ from Model.itemDto import ItemDto
 from util.abstractGameHandler import AbstractGameHandler
 import Dolphin.windWakerResources as WWR
 
+from PySide6.QtCore import Signal
+
 
 class ClientGameConnection:
     _items_to_process: List[ItemDto] = list()
@@ -15,13 +17,15 @@ class ClientGameConnection:
 
     _console_handler: AbstractGameHandler
 
+    gui_logger_signal: Signal
+
     def __init__(self, world_id: int):
         self._console_handler = DolphinGameHandler(world_id)
 
     async def process_items(self) -> None:
         while len(self._items_to_process) > 0:
             item_dto = self._items_to_process[-1]
-            print_item_dto(item_dto)
+            self.print_item_dto(item_dto)
             try:
                 if not await self._console_handler.give_item(item_dto.itemId):
                     await asyncio.sleep(3)
@@ -33,13 +37,13 @@ class ClientGameConnection:
                 del exc
 
     async def handle(self) -> None:
-        print("Connected To Console")
+        await self.log("Connected To Console")
         while await self._console_handler.is_connected():  # Thread set interval instead of a while loop would be better
             try:
                 state = await self._console_handler.get_queued_items()
                 if state[0] != 0 and state[1] != 0 and state[1] != 0xFF:
                     item_dto = ItemDto(self._world_id, 0, state[1])  # World ID should be set in client
-                    print_item_dto(item_dto)
+                    self.print_item_dto(item_dto)
                     self._items_to_send.append(item_dto)
                     await self._console_handler.clear_queued_items()
             except RuntimeError as rne:
@@ -48,17 +52,22 @@ class ClientGameConnection:
                 if len(self._items_to_process) > 0:
                     asyncio.create_task(self.process_items())
             await asyncio.sleep(0)
-        print("Disconnected from Console, attempting to reconnect.....")
+        await self.log("Disconnected from Console, attempting to reconnect.....")
 
-    async def connect(self) -> Task:
-        print("Connecting to Console")
+    async def connect(self, gui_logger_signal: Signal) -> Task:
+        self.gui_logger_signal = gui_logger_signal
+        await self.log("Connecting to Console")
         while not await self._console_handler.is_connected():
             await self._console_handler.connect()
             if await self._console_handler.is_connected():
                 break
             await asyncio.sleep(15)
-            print("Console was not found, trying again in 15 seconds.")
+            await self.log("Console was not found, trying again in 15 seconds.")
         return asyncio.create_task(self.handle())
+
+    async def log(self, message: str) -> None:
+        assert isinstance(self.gui_logger_signal, Signal)
+        self.gui_logger_signal.emit(message)
 
     def get_item_to_send(self) -> List[ItemDto]:
         return self._items_to_send
@@ -68,7 +77,6 @@ class ClientGameConnection:
 
     def push_item_to_process(self, item_dto: ItemDto) -> None:
         self._items_to_process.append(item_dto)
-
-
-def print_item_dto(itemDto: ItemDto) -> None:
-    print(f"{WWR.item_name_dict[itemDto.itemId]} was found in world {itemDto.sourcePlayerWorldId}")
+    
+    async def print_item_dto(self, itemDto: ItemDto) -> None:
+        await self.log(f"{WWR.item_name_dict[itemDto.itemId]} was found in world {itemDto.sourcePlayerWorldId}")

--- a/Client/clientGameConnection.py
+++ b/Client/clientGameConnection.py
@@ -66,8 +66,10 @@ class ClientGameConnection:
         return asyncio.create_task(self.handle())
 
     async def log(self, message: str) -> None:
-        assert isinstance(self.gui_logger_signal, Signal)
-        self.gui_logger_signal.emit(message)
+        if isinstance(self.gui_logger_signal, Signal):
+            self.gui_logger_signal.emit(message)
+        else:
+            print(message)
 
     def get_item_to_send(self) -> List[ItemDto]:
         return self._items_to_send

--- a/Client/clientGameConnection.py
+++ b/Client/clientGameConnection.py
@@ -25,7 +25,7 @@ class ClientGameConnection:
     async def process_items(self) -> None:
         while len(self._items_to_process) > 0:
             item_dto = self._items_to_process[-1]
-            self.print_item_dto(item_dto)
+            await self.print_item_dto(item_dto)
             try:
                 if not await self._console_handler.give_item(item_dto.itemId):
                     await asyncio.sleep(3)
@@ -43,7 +43,7 @@ class ClientGameConnection:
                 state = await self._console_handler.get_queued_items()
                 if state[0] != 0 and state[1] != 0 and state[1] != 0xFF:
                     item_dto = ItemDto(self._world_id, 0, state[1])  # World ID should be set in client
-                    self.print_item_dto(item_dto)
+                    await self.print_item_dto(item_dto)
                     self._items_to_send.append(item_dto)
                     await self._console_handler.clear_queued_items()
             except RuntimeError as rne:

--- a/Model/config.py
+++ b/Model/config.py
@@ -9,6 +9,7 @@ class Config:
     _Port: int = 8080
     _World_id: int = 0
     _Game_Room: str = ""
+    _Max_Players: int = 2
     _root_dir: str = "."
     Scanner_Enabled: bool = False
     Scan_Treasure: bool = False
@@ -40,6 +41,7 @@ class Config:
 
         self._World_id = int(self._config_parser.get('GAME', 'world_id',fallback=0))
         self._Game_Room = self._config_parser.get('GAME', 'gameroom_name')
+        self._Max_Players = int(self._config_parser.get('GAME', 'max_players', fallback=2))
 
         self.Scanner_Enabled = bool(self._config_parser.get('GAME', 'scan_flags', fallback=False))
         self.Scan_Treasure = bool(self._config_parser.get('GAME', 'scan_treasure', fallback=False))

--- a/Model/itemDto.py
+++ b/Model/itemDto.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, asdict
-
+import Dolphin.windWakerResources as WWR
 
 @dataclass
 class ItemDto:
@@ -20,3 +20,6 @@ class ItemDto:
 
     def as_dict(self):
         return asdict(self)
+    
+    def get_simple_output(self) -> str:
+        return f"{WWR.item_name_dict[self.itemId]} was found in world {self.sourcePlayerWorldId}"

--- a/View/multiworldClient.py
+++ b/View/multiworldClient.py
@@ -13,7 +13,7 @@ from Model.config import Config
 
 class ServerWorker(QObject):
     
-    message = Signal(str) # to communicate with parent thread
+    message = Signal(str) # to communicate with parent (gui) thread
 
     def __init__(self):
         super(ServerWorker, self).__init__()
@@ -27,12 +27,11 @@ class ServerWorker(QObject):
         set_up_dto = SetUpDto(1, self.config._Game_Room, None, False) # 1 = world amount, just 1 for testing to match with number assigned to input box
         try:
             print("Into Listener")
-            asyncio.run(clientFunctions.start_connections(server_config, set_up_dto, self.send_message))
+            asyncio.run(clientFunctions.start_connections(server_config, set_up_dto, self.message))
             
         except RuntimeWarning:
             self.send_message("Failed to Create Room")
 
-    @Slot(str)
     def send_message(self, msg: str): # to (maybe) receive messages from the actual connection things, haven't gotten that far yet
         self.message.emit(msg)
 

--- a/View/multiworldClient.py
+++ b/View/multiworldClient.py
@@ -110,3 +110,7 @@ class MultiworldClientWindow(QMainWindow):
         elif mode == "Set-up Room":
             self.ui.joinButton.hide()
             self.ui.serverButton.show()
+
+    def closeEvent(self, event) -> None: # Triggers when the user clicks the 'X' to close the window
+        self.disconnect()
+        event.accept() # Let the window close

--- a/View/multiworldClient.py
+++ b/View/multiworldClient.py
@@ -49,6 +49,8 @@ class MultiworldClientWindow(QMainWindow):
 
         self.ui.modeSelector.currentTextChanged.connect(self.show_button)
 
+        self.ServerThread = QThread()
+
         self.load_config()
         self.show()
 
@@ -79,7 +81,6 @@ class MultiworldClientWindow(QMainWindow):
     def create_room(self):
         self.update_config()
 
-        self.ServerThread = QThread()
         self.ServerMaker = ServerWorker()
         self.ServerMaker.moveToThread(self.ServerThread)
         self.ServerThread.started.connect(self.ServerMaker.run)

--- a/View/multiworldClient.py
+++ b/View/multiworldClient.py
@@ -80,14 +80,18 @@ class MultiworldClientWindow(QMainWindow):
     def create_room(self):
         self.update_config()
         print("Setting Fields")
-        server_config = ServerConfig(self.ui.serverIpInput.text().strip(), int(self.ui.serverPortInput.text().strip()),
-                                     int(self.ui.worldIdInput.text()), 'admin', 'adminPass')
-        set_up_dto = SetUpDto(int(self.ui.maxPlayersInput.text()), self.ui.gameRoomNameInput.text(), None, False)
-        try:
-            print("Into Listener")
-            asyncio.run(clientFunctions.start_connections(server_config, set_up_dto, self.ui.dialogLog))
-        except RuntimeWarning:
-            self.ui.dialogLog.addItem("Failed to Create Room")
+
+        self.ServerThread = QThread()
+        self.ServerMaker = ServerWorker()
+        self.ServerMaker.moveToThread(self.ServerThread)
+        self.ServerThread.started.connect(self.ServerMaker.run)
+        
+
+        self.ServerMaker.message.connect(self.log)
+        self.ServerThread.start()
+        
+        self.ui.serverButton.setEnabled(False)
+        self.ui.disconnectButton.show()
 
     def join_room(self):
         pass # TODO joining room stuff

--- a/View/multiworldClient.py
+++ b/View/multiworldClient.py
@@ -27,7 +27,7 @@ class ServerWorker(QObject):
         set_up_dto = SetUpDto(1, self.config._Game_Room, None, False) # 1 = world amount, just 1 for testing to match with number assigned to input box
         try:
             print("Into Listener")
-            asyncio.run(clientFunctions.start_connections(server_config, set_up_dto))
+            asyncio.run(clientFunctions.start_connections(server_config, set_up_dto, self.send_message))
             
         except RuntimeWarning:
             self.send_message("Failed to Create Room")
@@ -56,7 +56,7 @@ class MultiworldClientWindow(QMainWindow):
     @Slot(str)
     def log(self, message: str):
         self.ui.dialogLog.addItem(message)
-        self.ui.dialogLog.scrollToBottm()
+        self.ui.dialogLog.scrollToBottom()
 
     def load_config(self):
         self.config = Config.get_config()
@@ -79,7 +79,6 @@ class MultiworldClientWindow(QMainWindow):
 
     def create_room(self):
         self.update_config()
-        print("Setting Fields")
 
         self.ServerThread = QThread()
         self.ServerMaker = ServerWorker()

--- a/View/multiworldClient.py
+++ b/View/multiworldClient.py
@@ -16,9 +16,11 @@ class MultiworldClientWindow(QMainWindow):
         self.ui.setupUi(self)
         self.ui.serverButton.clicked.connect(self.create_room)
         self.ui.joinButton.clicked.connect(self.join_room)
-        self.ui.serverButton.hide() # By default the option is set to join, not setup
+        self.show_button() # Update button to only show the right one of the two to reflect the default value of modeSelector
         self.ui.disconnectButton.clicked.connect(self.disconnect)
         self.ui.disconnectButton.hide()
+
+        self.ui.modeSelector.currentTextChanged.connect(self.show_button)
 
         self.show()
 
@@ -38,3 +40,13 @@ class MultiworldClientWindow(QMainWindow):
 
     def disconnect(self):
         pass # TODO proper thread ending and server disconnect
+
+    def show_button(self):
+        # Used to display the correct button when the Mode Selector dropdown value changes
+        mode = self.ui.modeSelector.currentText()
+        if mode == "Connect to Room":
+            self.ui.joinButton.show()
+            self.ui.serverButton.hide()
+        elif mode == "Set-up Room":
+            self.ui.joinButton.hide()
+            self.ui.serverButton.show()

--- a/View/multiworldClient.py
+++ b/View/multiworldClient.py
@@ -15,7 +15,7 @@ class JoinServerWorker(QObject):
     
     message = Signal(str) # to communicate with parent (gui) thread
 
-    def __init__(self) -> None:
+    def __init__(self):
         super(JoinServerWorker, self).__init__()
         self.config = Config.get_config()
 
@@ -24,7 +24,7 @@ class JoinServerWorker(QObject):
         print("Setting Fields")
         server_config = ServerConfig(self.config._ServerAddress, self.config._Port,
         self.config._World_id, 'admin', 'adminPass')
-        set_up_dto = SetUpDto(1, self.config._Game_Room, None, False) # 1 = world amount, just 1 for testing to match with number assigned to input box
+        set_up_dto = SetUpDto(self.config._Max_Players, self.config._Game_Room, None, False)
         try:
             print("Into Listener")
             asyncio.run(clientFunctions.start_connections(server_config, set_up_dto, self.message))
@@ -66,7 +66,7 @@ class MultiworldClientWindow(QMainWindow):
         self.ui.serverPortInput.setText(str(self.config._Port))
         self.ui.gameRoomNameInput.setText(self.config._Game_Room)
         self.ui.worldIdInput.setText(str(self.config._World_id))
-        self.ui.maxPlayersInput.setText("1") #testing
+        self.ui.maxPlayersInput.setText(str(self.config._Max_Players))
 
     def update_config(self) -> None:
         if self.config._ServerAddress != self.ui.serverIpInput.text():
@@ -77,6 +77,8 @@ class MultiworldClientWindow(QMainWindow):
             self.config._Game_Room = self.ui.gameRoomNameInput.text().strip()
         if self.config._World_id != int(self.ui.worldIdInput.text()):
             self.config._World_id = int(self.ui.worldIdInput.text().strip())
+        if self.config._Max_Players != int(self.ui.maxPlayersInput.text()):
+            self.config_Max_Players = int(self.ui.maxPlayersInput.text().strip())
 
     def create_room(self) -> None:
         pass # TODO actual room setup, needs server-side implementation first

--- a/View/multiworldClient.py
+++ b/View/multiworldClient.py
@@ -96,7 +96,10 @@ class MultiworldClientWindow(QMainWindow):
         pass # TODO joining room stuff
 
     def disconnect(self):
-        pass # TODO proper thread ending and server disconnect
+        if self.ServerThread.isRunning():
+            self.ServerThread.requestInterruption()
+            self.ServerThread.wait()
+        self.ui.disconnectButton.hide()
 
     def show_button(self):
         # Used to display the correct button when the Mode Selector dropdown value changes

--- a/View/multiworldClient.py
+++ b/View/multiworldClient.py
@@ -36,7 +36,18 @@ class MultiworldClientWindow(QMainWindow):
         self.ui.worldIdInput.setText(str(self.config._World_id))
         self.ui.maxPlayersInput.setText("1") #testing
 
+    def update_config(self):
+        if self.config._ServerAddress != self.ui.serverIpInput.text():
+            self.config._ServerAddress = self.ui.serverIpInput.text().strip()
+        if self.config._Port != int(self.ui.serverPortInput.text()):
+            self.config._Port = int(self.ui.serverPortInput.text().strip())
+        if self.config._Game_Room != self.ui.gameRoomNameInput.text():
+            self.config._Game_Room = self.ui.gameRoomNameInput.text().strip()
+        if self.config._World_id != int(self.ui.worldIdInput.text()):
+            self.config._World_id = int(self.ui.worldIdInput.text().strip())
+
     def create_room(self):
+        self.update_config()
         print("Setting Fields")
         server_config = ServerConfig(self.ui.serverIpInput.text().strip(), int(self.ui.serverPortInput.text().strip()),
                                      int(self.ui.worldIdInput.text()), 'admin', 'adminPass')

--- a/View/multiworldClient.py
+++ b/View/multiworldClient.py
@@ -92,7 +92,7 @@ class MultiworldClientWindow(QMainWindow):
         self.ServerJoiner.message.connect(self.log)
         self.ServerThread.start()
         
-        self.ui.serverButton.setEnabled(False)
+        self.ui.joinButton.setEnabled(False)
         self.ui.disconnectButton.show()
 
     def disconnect(self) -> None:
@@ -100,6 +100,8 @@ class MultiworldClientWindow(QMainWindow):
             self.ServerThread.requestInterruption()
             self.ServerThread.wait()
         self.ui.disconnectButton.hide()
+        self.ui.joinButton.setEnabled(True)
+        self.ui.serverButton.setEnabled(True)
 
     def show_button(self) -> None:
         # Used to display the correct button when the Mode Selector dropdown value changes

--- a/View/multiworldClient.py
+++ b/View/multiworldClient.py
@@ -1,6 +1,7 @@
 import asyncio
 
 from PySide6.QtWidgets import *
+from PySide6.QtCore import QThread, QObject, Signal, Slot
 
 from View.uiMultiworldClient import uiMultiworldClient
 from Model.serverConfig import ServerConfig
@@ -9,6 +10,31 @@ import Client.clientCommunication as clientFunctions
 
 from Model.config import Config
 
+
+class ServerWorker(QObject):
+    
+    message = Signal(str) # to communicate with parent thread
+
+    def __init__(self):
+        super(ServerWorker, self).__init__()
+        self.config = Config.get_config()
+
+
+    def run(self):
+        print("Setting Fields")
+        server_config = ServerConfig(self.config._ServerAddress, self.config._Port,
+        self.config._World_id, 'admin', 'adminPass')
+        set_up_dto = SetUpDto(1, self.config._Game_Room, None, False) # 1 = world amount, just 1 for testing to match with number assigned to input box
+        try:
+            print("Into Listener")
+            asyncio.run(clientFunctions.start_connections(server_config, set_up_dto))
+            
+        except RuntimeWarning:
+            self.send_message("Failed to Create Room")
+
+    @Slot(str)
+    def send_message(self, msg: str): # to (maybe) receive messages from the actual connection things, haven't gotten that far yet
+        self.message.emit(msg)
 
 class MultiworldClientWindow(QMainWindow):
 

--- a/View/multiworldClient.py
+++ b/View/multiworldClient.py
@@ -15,12 +15,12 @@ class ServerWorker(QObject):
     
     message = Signal(str) # to communicate with parent (gui) thread
 
-    def __init__(self):
+    def __init__(self) -> None:
         super(ServerWorker, self).__init__()
         self.config = Config.get_config()
 
 
-    def run(self):
+    def run(self) -> None:
         print("Setting Fields")
         server_config = ServerConfig(self.config._ServerAddress, self.config._Port,
         self.config._World_id, 'admin', 'adminPass')
@@ -32,12 +32,12 @@ class ServerWorker(QObject):
         except RuntimeWarning:
             self.send_message("Failed to Create Room")
 
-    def send_message(self, msg: str): # to (maybe) receive messages from the actual connection things, haven't gotten that far yet
+    def send_message(self, msg: str) -> None: # to (maybe) receive messages from the actual connection things, haven't gotten that far yet
         self.message.emit(msg)
 
 class MultiworldClientWindow(QMainWindow):
 
-    def __init__(self):
+    def __init__(self) -> None:
         super(MultiworldClientWindow, self).__init__()
         self.ui = uiMultiworldClient()
         self.ui.setupUi(self)
@@ -55,11 +55,11 @@ class MultiworldClientWindow(QMainWindow):
         self.show()
 
     @Slot(str)
-    def log(self, message: str):
+    def log(self, message: str) -> None:
         self.ui.dialogLog.addItem(message)
         self.ui.dialogLog.scrollToBottom()
 
-    def load_config(self):
+    def load_config(self) -> None:
         self.config = Config.get_config()
 
         self.ui.serverIpInput.setText(self.config._ServerAddress)
@@ -68,7 +68,7 @@ class MultiworldClientWindow(QMainWindow):
         self.ui.worldIdInput.setText(str(self.config._World_id))
         self.ui.maxPlayersInput.setText("1") #testing
 
-    def update_config(self):
+    def update_config(self) -> None:
         if self.config._ServerAddress != self.ui.serverIpInput.text():
             self.config._ServerAddress = self.ui.serverIpInput.text().strip()
         if self.config._Port != int(self.ui.serverPortInput.text()):
@@ -78,7 +78,7 @@ class MultiworldClientWindow(QMainWindow):
         if self.config._World_id != int(self.ui.worldIdInput.text()):
             self.config._World_id = int(self.ui.worldIdInput.text().strip())
 
-    def create_room(self):
+    def create_room(self) -> None:
         self.update_config()
 
         self.ServerMaker = ServerWorker()
@@ -92,16 +92,16 @@ class MultiworldClientWindow(QMainWindow):
         self.ui.serverButton.setEnabled(False)
         self.ui.disconnectButton.show()
 
-    def join_room(self):
+    def join_room(self) -> None:
         pass # TODO joining room stuff
 
-    def disconnect(self):
+    def disconnect(self) -> None:
         if self.ServerThread.isRunning():
             self.ServerThread.requestInterruption()
             self.ServerThread.wait()
         self.ui.disconnectButton.hide()
 
-    def show_button(self):
+    def show_button(self) -> None:
         # Used to display the correct button when the Mode Selector dropdown value changes
         mode = self.ui.modeSelector.currentText()
         if mode == "Connect to Room":

--- a/View/multiworldClient.py
+++ b/View/multiworldClient.py
@@ -15,6 +15,11 @@ class MultiworldClientWindow(QMainWindow):
         self.ui = uiMultiworldClient()
         self.ui.setupUi(self)
         self.ui.serverButton.clicked.connect(self.create_room)
+        self.ui.joinButton.clicked.connect(self.join_room)
+        self.ui.serverButton.hide() # By default the option is set to join, not setup
+        self.ui.disconnectButton.clicked.connect(self.disconnect)
+        self.ui.disconnectButton.hide()
+
         self.show()
 
     def create_room(self):
@@ -27,3 +32,9 @@ class MultiworldClientWindow(QMainWindow):
             asyncio.run(clientFunctions.start_connections(server_config, set_up_dto, self.ui.dialogLog))
         except RuntimeWarning:
             self.ui.dialogLog.addItem("Failed to Create Room")
+
+    def join_room(self):
+        pass # TODO joining room stuff
+
+    def disconnect(self):
+        pass # TODO proper thread ending and server disconnect

--- a/View/multiworldClient.py
+++ b/View/multiworldClient.py
@@ -11,12 +11,12 @@ import Client.clientCommunication as clientFunctions
 from Model.config import Config
 
 
-class ServerWorker(QObject):
+class JoinServerWorker(QObject):
     
     message = Signal(str) # to communicate with parent (gui) thread
 
     def __init__(self) -> None:
-        super(ServerWorker, self).__init__()
+        super(JoinServerWorker, self).__init__()
         self.config = Config.get_config()
 
 
@@ -79,21 +79,21 @@ class MultiworldClientWindow(QMainWindow):
             self.config._World_id = int(self.ui.worldIdInput.text().strip())
 
     def create_room(self) -> None:
+        pass # TODO actual room setup, needs server-side implementation first
+
+    def join_room(self) -> None:
         self.update_config()
 
-        self.ServerMaker = ServerWorker()
-        self.ServerMaker.moveToThread(self.ServerThread)
-        self.ServerThread.started.connect(self.ServerMaker.run)
+        self.ServerJoiner = JoinServerWorker()
+        self.ServerJoiner.moveToThread(self.ServerThread)
+        self.ServerThread.started.connect(self.ServerJoiner.run)
         
 
-        self.ServerMaker.message.connect(self.log)
+        self.ServerJoiner.message.connect(self.log)
         self.ServerThread.start()
         
         self.ui.serverButton.setEnabled(False)
         self.ui.disconnectButton.show()
-
-    def join_room(self) -> None:
-        pass # TODO joining room stuff
 
     def disconnect(self) -> None:
         if self.ServerThread.isRunning():

--- a/View/multiworldClient.py
+++ b/View/multiworldClient.py
@@ -53,6 +53,11 @@ class MultiworldClientWindow(QMainWindow):
         self.load_config()
         self.show()
 
+    @Slot(str)
+    def log(self, message: str):
+        self.ui.dialogLog.addItem(message)
+        self.ui.dialogLog.scrollToBottm()
+
     def load_config(self):
         self.config = Config.get_config()
 

--- a/View/multiworldClient.py
+++ b/View/multiworldClient.py
@@ -7,6 +7,8 @@ from Model.serverConfig import ServerConfig
 from Model.setUpDto import SetUpDto
 import Client.clientCommunication as clientFunctions
 
+from Model.config import Config
+
 
 class MultiworldClientWindow(QMainWindow):
 
@@ -22,7 +24,17 @@ class MultiworldClientWindow(QMainWindow):
 
         self.ui.modeSelector.currentTextChanged.connect(self.show_button)
 
+        self.load_config()
         self.show()
+
+    def load_config(self):
+        self.config = Config.get_config()
+
+        self.ui.serverIpInput.setText(self.config._ServerAddress)
+        self.ui.serverPortInput.setText(str(self.config._Port))
+        self.ui.gameRoomNameInput.setText(self.config._Game_Room)
+        self.ui.worldIdInput.setText(str(self.config._World_id))
+        self.ui.maxPlayersInput.setText("1") #testing
 
     def create_room(self):
         print("Setting Fields")

--- a/View/multiworldClient.ui
+++ b/View/multiworldClient.ui
@@ -244,6 +244,32 @@
      <string> Ready to Play</string>
     </property>
    </widget>
+   <widget class="QPushButton" name="joinButton">
+    <property name="geometry">
+     <rect>
+      <x>20</x>
+      <y>280</y>
+      <width>75</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Join</string>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="disconnectButton">
+    <property name="geometry">
+     <rect>
+      <x>110</x>
+      <y>280</y>
+      <width>75</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Disconnect</string>
+    </property>
+   </widget>
   </widget>
  </widget>
  <resources/>

--- a/View/uiMultiworldClient.py
+++ b/View/uiMultiworldClient.py
@@ -88,6 +88,12 @@ class uiMultiworldClient(object):
         self.readyBox.setObjectName(u"readyBox")
         self.readyBox.setGeometry(QRect(200, 280, 90, 20))
         self.readyBox.setLayoutDirection(Qt.RightToLeft)
+        self.joinButton = QPushButton(self.centralwidget)
+        self.joinButton.setObjectName(u"joinButton")
+        self.joinButton.setGeometry(QRect(20, 280, 75, 25))
+        self.disconnectButton = QPushButton(self.centralwidget)
+        self.disconnectButton.setObjectName(u"disconnectButton")
+        self.disconnectButton.setGeometry(QRect(110, 280, 75, 25))
         MainWindow.setCentralWidget(self.centralwidget)
 
         self.retranslateUi(MainWindow)
@@ -110,5 +116,7 @@ class uiMultiworldClient(object):
         self.serverIPLabel.setText(QCoreApplication.translate("MainWindow", u"Server IP", None))
         self.gameRoomNameLabel.setText(QCoreApplication.translate("MainWindow", u"Room Name", None))
         self.readyBox.setText(QCoreApplication.translate("MainWindow", u" Ready to Play", None))
+        self.joinButton.setText(QCoreApplication.translate("MainWindow", u"Join", None))
+        self.disconnectButton.setText(QCoreApplication.translate("MainWindow", u"Disconnect", None))
     # retranslateUi
 

--- a/config.ini
+++ b/config.ini
@@ -7,3 +7,4 @@ world_id = 1
 max_players = 255
 gameroom_name =
 random_rupoors =
+max_players = 2


### PR DESCRIPTION
#2 

This largely keeps the same gui files, but adds 2 buttons, one to join rooms and one to disconnect rooms. The Set-Up button now does nothing since room creation is not actually supported server-side yet.

The relevant fields are automatically populated on load with values from the current `Config`.

Pressing the 'Join' button will create a new thread that will join the server, and make a 'Disconnect' button show up. This disconnect button will request an interruption which will be caught by the main client loop in `clientCommunication.client()`, then properly disconnecting and ending the thread. The same will happen when the user attempts to close the window when connected. 

There is also now a Qt Signal passed down from the main gui to the connection classes. Emitting this signal with a string will add said string to the `QListWidget` on the main gui, displaying a message to the user. This can be made a lot cleaner, but for now it works. 

Note that this still is not loaded by `main.py`, it still is currently only implemented by `testing.py`. It simply is closer to being ready to be properly impmlemented into `main.py`.